### PR TITLE
Fix js callback hell example errors

### DIFF
--- a/src/posts/2019-05-08-nested-callbacks.md
+++ b/src/posts/2019-05-08-nested-callbacks.md
@@ -221,7 +221,7 @@ If you take advantage of the single-argument style with promises, you can tweak 
 const makeBurger = () => {
   return getBeef()
     .then(cookBeef)
-    .then(cookedBeef => getBuns().then(buns => putBeefBetweenBuns(buns, cookedBeef))
+    .then(cookedBeef => getBuns().then(buns => putBeefBetweenBuns(buns, cookedBeef)))
 }
 
 // Make and serve burger 

--- a/src/posts/2019-05-08-nested-callbacks.md
+++ b/src/posts/2019-05-08-nested-callbacks.md
@@ -59,7 +59,7 @@ const makeBurger = () => {
   const beef = getBeef()
   const patty = cookBeef(beef)
   const buns = getBuns()
-  const burger = putBeefBetweenBuns(buns, beef)
+  const burger = putBeefBetweenBuns(buns, patty)
   return burger
 }
 
@@ -102,7 +102,7 @@ const makeBurger = () => {
   getBeef(function (beef) {
     cookBeef(beef, function (cookedBeef) {
       getBuns(function (buns) {
-        putBeefBetweenBuns(buns, beef, function(burger) {
+        putBeefBetweenBuns(buns, cookedBeef, function(burger) {
           // Serve the burger 
         })
       })
@@ -118,7 +118,7 @@ const makeBurger = nextStep => {
   getBeef(function (beef) {
     cookBeef(beef, function (cookedBeef) {
       getBuns(function (buns) {
-        putBeefBetweenBuns(buns, beef, function(burger) {
+        putBeefBetweenBuns(buns, cookedBeef, function(burger) {
           nextStep(burger)
         })
       })
@@ -127,7 +127,7 @@ const makeBurger = nextStep => {
 }
 
 // Make and serve the burger
-makeBurger(function (burger) => {
+makeBurger(function (burger) {
   serve(burger)
 })
 ```
@@ -157,7 +157,7 @@ const makeBurger = nextStep => {
   getBeef(function (beef) {
     cookBeef(beef, function (cookedBeef) {
       getBuns(function (buns) {
-        putBeefBetweenBuns(buns, beef, function(burger) {
+        putBeefBetweenBuns(buns, cookedBeef, function(burger) {
           nextStep(burger)
         })
       })
@@ -176,7 +176,7 @@ For `getBeef`, our first callback, we have to go to the fridge to get the beef. 
 
 ```js
 const getBeef = (nextStep) => {
-  const fridge = leftFright
+  const fridge = leftFridge
   const beef = getBeefFromFridge(fridge)
   nextStep(beef)
 }
@@ -186,7 +186,7 @@ To cook beef, we need to put the beef into an oven; turn the oven to 200 degrees
 
 ```js
 const cookBeef = (beef, nextStep) => {
-  const workInProgress = putBeefinOven(beef)
+  const workInProgress = putBeefInOven(beef)
   setTimeout (function () {
     nextStep(workInProgress)
  }, 1000 * 60 * 20)
@@ -207,8 +207,7 @@ Promises can make callback hell much easier to manage. Instead of the nested cod
 const makeBurger = () => {
   return getBeef()
     .then(beef => cookBeef(beef))
-    .then(cookedBeef => getBuns(beef))
-    .then(bunsAndBeef => putBeefBetweenBuns(bunsAndBeef))
+    .then(cookedBeef => getBuns().then(buns => putBeefBetweenBuns(buns, cookedBeef)))
 }
 
 // Make and serve burger 
@@ -222,8 +221,7 @@ If you take advantage of the single-argument style with promises, you can tweak 
 const makeBurger = () => {
   return getBeef()
     .then(cookBeef)
-    .then(getBuns)
-    .then(putBeefBetweenBuns)
+    .then(cookedBeef => getBuns().then(buns => putBeefBetweenBuns(buns, cookedBeef))
 }
 
 // Make and serve burger 
@@ -241,7 +239,7 @@ To convert callbacks into promises, we need to create a new promise for each cal
 
 ```js
 const getBeefPromise = _ => {
-  const fridge = leftFright
+  const fridge = leftFridge
   const beef = getBeefFromFridge(fridge)
 
   return new Promise((resolve, reject) => {
@@ -256,7 +254,7 @@ const getBeefPromise = _ => {
 
 ```js
 const cookBeefPromise = beef => {
-  const workInProgress = putBeefinOven(beef)
+  const workInProgress = putBeefInOven(beef)
 
   return new Promise((resolve, reject) => {  
     setTimeout (function () {
@@ -305,7 +303,7 @@ const makeBurger = async () => {
   const beef = await getBeef()
   const cookedBeef = await cookBeef(beef)
   const buns = await getBuns()
-  const burger = await putBeefBetweenBuns(cookedBeef, buns)
+  const burger = await putBeefBetweenBuns(buns, cookedBeef)
   return burger 
 }
 
@@ -318,9 +316,9 @@ There's one improvement we can make to the `makeBurger` here. You can probably g
 
 ```js
 const makeBurger = async () => {
-  const [beef, buns] = await Promise.all(getBeef, getBuns)
+  const [beef, buns] = await Promise.all([getBeef(), getBuns()])
   const cookedBeef = await cookBeef(beef)
-  const burger = await putBeefBetweenBuns(cookedBeef, buns)
+  const burger = await putBeefBetweenBuns(buns, cookedBeef)
   return burger 
 }
 

--- a/src/posts/2019-05-08-nested-callbacks.md
+++ b/src/posts/2019-05-08-nested-callbacks.md
@@ -207,7 +207,8 @@ Promises can make callback hell much easier to manage. Instead of the nested cod
 const makeBurger = () => {
   return getBeef()
     .then(beef => cookBeef(beef))
-    .then(cookedBeef => getBuns().then(buns => putBeefBetweenBuns(buns, cookedBeef)))
+    .then(cookedBeef => getBuns(cookedBeef))
+    .then(bunsAndBeef => putBeefBetweenBuns(bunsAndBeef))
 }
 
 // Make and serve burger 
@@ -221,7 +222,8 @@ If you take advantage of the single-argument style with promises, you can tweak 
 const makeBurger = () => {
   return getBeef()
     .then(cookBeef)
-    .then(cookedBeef => getBuns().then(buns => putBeefBetweenBuns(buns, cookedBeef)))
+    .then(getBuns)
+    .then(putBeefBetweenBuns)
 }
 
 // Make and serve burger 


### PR DESCRIPTION
* Fixes wrong param passed to putBeefBetweenBuns (cooked beef instead of raw)
* Fixes syntax error in makeBurger callback (mix of function and arrow syntax)
* Fixes typo: leftFright -> leftFridge
* Fixes typo: putBeefinOven -> putBeefInOven
* Changes promise example to nest instead of having getBuns take in beef
* Fixes param order of putBeefBetweenBuns in async/await examples

Signed-off-by: Ryan Bard <john.ryan.bard@gmail.com>