### PR TITLE
Match name of function to example

### DIFF
--- a/src/posts/2018-02-28-responsive-vertical-rhythm-with-css-variables.md
+++ b/src/posts/2018-02-28-responsive-vertical-rhythm-with-css-variables.md
@@ -188,7 +188,7 @@ It can be a chore to write `calc` and `var` every time you create a rhythm value
 }
 ```
 
-Then, you can use the `vr` function you've created like this. Much simpler! 💃.
+Then, you can use the `rvr` function you've created like this. Much simpler! 💃.
 
 ```scss
 /* Two rhythm units */


### PR DESCRIPTION
Just a small one!

The function name mentioned in the copy, didn't match up with the function name used in the examples around it.