### PR TITLE
Remove an extra backtick in Timing Functions section

### DIFF
--- a/src/posts/2017-12-27.animating-with-gsap.md
+++ b/src/posts/2017-12-27.animating-with-gsap.md
@@ -149,7 +149,7 @@ const vars = {
 }
 ```
 
-GSAP provides you with many easing variables like ``Power0`, `Power1`, `Power2`, `Power3` and `Power4`. These easing variables tell GSAP how strong the easing needs to be.
+GSAP provides you with many easing variables like `Power0`, `Power1`, `Power2`, `Power3` and `Power4`. These easing variables tell GSAP how strong the easing needs to be.
 
 `Power0` gives you the normal ease-in and ease-out values, `Power1` gives you the quadratic ease-in and ease-out values, and `Power2` gives you the cubic ease-in and cubic ease-out values, and so on.
 


### PR DESCRIPTION
Hi Zell, 

I found a small markdown error in this post https://zellwk.com/blog/gsap/, in Timing Functions section.
There is an extra backtick <code>`</code> that causes weird output.

currently it is:

<img width="641" alt="Screen Shot 2019-07-24 at 14 22 57" src="https://user-images.githubusercontent.com/911894/61773769-a2cbdf80-ae1f-11e9-8ec0-7718e552ec02.png">

what I think it should be:

<img width="636" alt="Screen Shot 2019-07-24 at 14 23 49" src="https://user-images.githubusercontent.com/911894/61773796-b2e3bf00-ae1f-11e9-8c2e-54124c5aa3b1.png">

This pull request fixes the issue.

And thanks for the great post, by the way!
Cheers,
Armno
