### PR TITLE
mongoose.connect error

### DIFF
--- a/src/posts/2019-07-31-local-mongodb.md
+++ b/src/posts/2019-07-31-local-mongodb.md
@@ -202,7 +202,7 @@ const url = 'mongodb://127.0.0.1:27017/game-of-thrones'
 You can connect to MongoDB with the `connect` method:
 
 ```js
-mongoose.connect('url', { useNewUrlParser: true })
+mongoose.connect(url, { useNewUrlParser: true })
 ```
 
 Here's how you can check whether the connection succeeds.


### PR DESCRIPTION
mongoose.connect('url', {useNewUrlParser:true} throws an error: Invalid connection string. The url should not be wrapped with single quotes. Removing the single quotes resolved the error for me.