### PR TITLE
Update 2018-06-13-dont-reassign.md

### DIFF
--- a/src/posts/2018-06-13-dont-reassign.md
+++ b/src/posts/2018-06-13-dont-reassign.md
@@ -145,7 +145,7 @@ if (today === 'Monday') {
 }
 ```
 
-The best way to handle many `if/else` statements (or even a `switch`) statement is to contain the `if/else` logic in a function.
+The best way to handle many `if/else` statements (or even a `switch` statement) is to contain the `if/else` logic in a function.
 
 Here's a start (where we simply wrap a function around the above code):
 


### PR DESCRIPTION
Moved closing parenthesis after `switch` to after "statement" on line 148 so line now reads "...(or even a `switch` statement)...."