### PR TITLE
fix: improve spelling

### DIFF
--- a/src/_includes/_layout/post.njk
+++ b/src/_includes/_layout/post.njk
@@ -81,7 +81,7 @@ footer: true
 
         Please [contact me](/contact) if you want to talk to me about this article.
 
-        If you spot a typo, I'd appreciate if you can correct [this page on Github](https://github.com/zellwk/zellwk.com/blob/master/{{ page.inputPath }}). Thank you!
+        If you spot a typo, I'd appreciate if you can correct [this page on GitHub](https://github.com/zellwk/zellwk.com/blob/master/{{ page.inputPath }}). Thank you!
       {%- endmarkdown -%}
     </div>
   </aside>


### PR DESCRIPTION
Noticed potential improvement for the blog post footer areas.

### Proposed changes

- Improve spelling
  - Change `Github` to `GitHub` on the post footer area