### PR TITLE
Fixed Indrek's Codepen link

### DIFF
--- a/src/posts/2016-03-09-viewport-typography.md
+++ b/src/posts/2016-03-09-viewport-typography.md
@@ -320,7 +320,7 @@ html {
 }
 ```
 
-Indrek has been kind enough to put up a Codepen demo for this at http://codepen.io/indrekpaas/pen/VarLaJ. Check it out!
+Indrek has been kind enough to put up a Codepen demo for this at [http://codepen.io/indrekpaas/pen/VarLaJ](http://codepen.io/indrekpaas/pen/VarLaJ). Check it out!
 
 ## Wrapping Up
 


### PR DESCRIPTION
Changed the last link to markdown syntax, because GitHub automatically converts URLs to anchors, but on the actual website (https://zellwk.com/blog/viewport-based-typography/) the URL was showing as plain text.