### PR TITLE
Fix: style.transform always returns 'none' in Firefox

### DIFF
--- a/src/posts/2020-06-24-css-translate-values-in-javascript.md
+++ b/src/posts/2020-06-24-css-translate-values-in-javascript.md
@@ -121,7 +121,7 @@ I packed this up into a nice function for us to use.
  */
 function getTranslateValues (element) {
   const style = window.getComputedStyle(element)
-  const matrix = style.transform || style.webkitTransform || style.mozTransform
+  const matrix = style['transform'] || style.webkitTransform || style.mozTransform
 
   // No transform property. Simply return 0 values.
   if (matrix === 'none') {


### PR DESCRIPTION
"style.transform" works in Chrome but not in Firefox (80.0.1). In Firefox, it always returns 'none'. 
Got it to work in all browsers by changing it to "style['transform']"