### PR TITLE
Update 2019-09-25-async-await-express.md

### DIFF
--- a/src/posts/2019-09-25-async-await-express.md
+++ b/src/posts/2019-09-25-async-await-express.md
@@ -170,7 +170,7 @@ A simple way is to change the `try/catch` into a promise. This feels more friend
 
 ```js
 app.post('/signup', async(req, res, next) => {
-  function runAsync () {
+  async function runAsync () {
     await firstThing()
     await secondThing()
   }


### PR DESCRIPTION
Must add `async` keyword before `function runAsync ()` otherwise we will encounter an error : 
**SyntaxError: await is only valid in async function**