### PR TITLE
Fix a typo

### DIFF
--- a/src/posts/2016-02-17-rem-vs-em.md
+++ b/src/posts/2016-02-17-rem-vs-em.md
@@ -42,7 +42,7 @@ h1 { font-size: 2em } /* What does this even mean?! */
 
 What's the actual size of the `h1` selector here?
 
-We have to look at the parent element in order to compute the `<h1>`'s `font-size`. Let's say the parent element is `<html>`, and its `font-size` is set to ``16px`.
+We have to look at the parent element in order to compute the `<h1>`'s `font-size`. Let's say the parent element is `<html>`, and its `font-size` is set to `16px`.
 
 When put this way, we can see that the computed value of `<h1>` is `32px`, or `2 * 16px`.
 


### PR DESCRIPTION
There was a surplus backtick character that caused the Markdown to not be rendered correctly.