### PR TITLE
Add missing language definition

### DIFF
--- a/src/posts/2016-02-17-rem-vs-em.md
+++ b/src/posts/2016-02-17-rem-vs-em.md
@@ -473,7 +473,7 @@ Imagine if you had a grid like this. The vertical and horizontal spaces between 
 
 The markup for this grid is:
 
-```
+```html
 <div class="grid">
   <div class="grid-item">
     <div class="component"> <!-- component --> </div>


### PR DESCRIPTION
The code block with the HTML snippet was lacking its language definition and therefore was rendered without the HTML syntax highlighting.