### PR TITLE
Added space after full stop under That's crazy! heading

### DIFF
--- a/src/page/about.njk
+++ b/src/page/about.njk
@@ -45,7 +45,7 @@ footer: true
     - Wrote a programming book 2 years after I started coding 😱
     - Gave a talk at a conference 3 years after I started coding 😱
 
-    **It's amazing how far you can go when you don't stop yourself.** You're much better than you think you are.This statement is for both of us.
+    **It's amazing how far you can go when you don't stop yourself.** You're much better than you think you are. This statement is for both of us.
 
     My story just proves that **you can learn to design and code too.**
 


### PR DESCRIPTION
There is one typo on the about page. To be specific, it's under the heading, **That's crazy!**. There was a missing space after the sentence, `You're much better than you think you are. `