### PR TITLE
Update 2019-05-01-async-await-in-loops.md

### DIFF
--- a/src/posts/2019-05-01-async-await-in-loops.md
+++ b/src/posts/2019-05-01-async-await-in-loops.md
@@ -339,7 +339,7 @@ There are three steps to use `await` and `filter` properly:
 const filterLoop = async _ => {
   console.log('Start')
 
-  const promises = await fruitsToGet.map(fruit => getNumFruit(fruit))
+  const promises = fruitsToGet.map(fruit => getNumFruit(fruit))
   const numFruits = await Promise.all(promises)
 
   const moreThan20 = fruitsToGet.filter((fruit, index) => {


### PR DESCRIPTION
thanks for your blog post.

I was working why there was an `await` in front of `fruitsToGet.map(fruit => getNumFruit(fruit))`

map isn't returning a promise, it's returning an array of promises, isn't it ?