### PR TITLE
removed redundant await from final filterLoop func

### DIFF
--- a/src/posts/2019-05-01-async-await-in-loops.md
+++ b/src/posts/2019-05-01-async-await-in-loops.md
@@ -339,7 +339,7 @@ There are three steps to use `await` and `filter` properly:
 const filterLoop = async _ => {
   console.log('Start')
 
-  const promises = await fruitsToGet.map(fruit => getNumFruit(fruit))
+  const promises = fruitsToGet.map(fruit => getNumFruit(fruit))
   const numFruits = await Promise.all(promises)
 
   const moreThan20 = fruitsToGet.filter((fruit, index) => {


### PR DESCRIPTION
The promises variable definition (line 342) in final version of filterLoop function has redundant await prepending right side expression.
love the blog,
Łukasz